### PR TITLE
Update OCCT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(SYSTEM_OPENCASCADE "Use an external/system copy of OpenCASCADE" OFF)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(SYSTEM_OPENCASCADE)
+  # this is used for system packagers like fedora
   find_package(OpenCASCADE CONFIG REQUIRED)
   # Set path to header files directories
   target_include_directories(cascadio PUBLIC "${OpenCASCADE_INCLUDE_DIR}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "cascadio"
-version = "0.0.12"
+version = "0.0.13"
 requires-python = ">=3.7"
 authors = [{name = "Michael Dawson-Haggerty", email = "mikedh@kerfed.com"}]
 license = {file = "LICENSE/LICENSE-cascadio.md"}


### PR DESCRIPTION
- update to latest commit of OpenCascade
- release #7 for system packagers (i.e. fedeora, debian, etc). 