### PR TITLE
Require scikit-build-core>=0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit_build_core[pyproject]",
+requires = ["scikit_build_core >= 0.9.0",
             "pybind11"]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
- Do not require its “`pyproject`” extra, which is empty since 0.9.0 and may be removed in 1.0.

See:
https://github.com/scikit-build/scikit-build-core/commit/30d5d83b7a5b712df6b8df2c32ef1862c496fda1

This is basically for forward compatibility with a future `scikit-build-core` 1.0. This PR was prompted by a discussion with the maintainer of the `python-scikit-build-core` package in Fedora.