### PR TITLE
Expose node name format as a configurable parameter for GLB export

### DIFF
--- a/src/cascadio/__init__.py
+++ b/src/cascadio/__init__.py
@@ -10,6 +10,7 @@ from typing import Literal, Optional, Set
 # Import the C extension functions and enums
 from cascadio._core import (
     FileType,
+    NodeNameFormat,
     to_glb_bytes,
     step_to_glb,
     step_to_obj,
@@ -42,6 +43,7 @@ def load(
     include_brep: bool = False,
     brep_types: Optional[Set[BrepType]] = None,
     include_materials: bool = False,
+    node_name_format: NodeNameFormat = NodeNameFormat.PRODUCT_OR_INSTANCE,
 ) -> bytes:
     """
     Convert BREP data (STEP or IGES) to GLB format.
@@ -116,6 +118,7 @@ def load(
         include_brep=include_brep,
         brep_types=brep_types,
         include_materials=include_materials,
+        node_name_format=node_name_format,
     )
 
 

--- a/src/cascadio/__init__.py
+++ b/src/cascadio/__init__.py
@@ -43,7 +43,7 @@ def load(
     include_brep: bool = False,
     brep_types: Optional[Set[BrepType]] = None,
     include_materials: bool = False,
-    node_name_format: NodeNameFormat = NodeNameFormat.PRODUCT_OR_INSTANCE,
+    node_name_format: NodeNameFormat = NodeNameFormat.INSTANCE_OR_PRODUCT,
 ) -> bytes:
     """
     Convert BREP data (STEP or IGES) to GLB format.

--- a/src/convert.hpp
+++ b/src/convert.hpp
@@ -154,11 +154,13 @@ static bool exportToGlbFile(
     bool merge_primitives, bool use_parallel,
     std::vector<FaceTriangleData> *faceData = nullptr,
     RWGltf_CafWriter::JsonPostProcessCallback jsonCallback = nullptr,
-    RWGltf_CafWriter::BinaryAppendCallback binaryCallback = nullptr) {
+    RWGltf_CafWriter::BinaryAppendCallback binaryCallback = nullptr,
+    RWMesh_NameFormat node_name_format = RWMesh_NameFormat_InstanceOrProduct) {
   RWGltf_CafWriter cafWriter(output_path, true);
   cafWriter.SetMergeFaces(merge_primitives);
   cafWriter.SetParallel(use_parallel);
   cafWriter.SetTransformationFormat(RWGltf_WriterTrsfFormat_Mat4);
+  cafWriter.SetNodeNameFormat(node_name_format);
 
   // Set callback to collect face data if requested
   if (faceData != nullptr) {
@@ -191,7 +193,8 @@ static std::vector<char> exportToGlbBytes(
     Handle(TDocStd_Document) doc, bool merge_primitives, bool use_parallel,
     std::vector<FaceTriangleData> *faceData = nullptr,
     RWGltf_CafWriter::JsonPostProcessCallback jsonCallback = nullptr,
-    RWGltf_CafWriter::BinaryAppendCallback binaryCallback = nullptr) {
+    RWGltf_CafWriter::BinaryAppendCallback binaryCallback = nullptr,
+    RWMesh_NameFormat node_name_format = RWMesh_NameFormat_InstanceOrProduct) {
   // OCCT's RWGltf_CafWriter requires a file path. With our memfd patch,
   // both the output and internal .bin.tmp use memfd on Linux - zero filesystem
   // writes. Falls back to temp files on other platforms.
@@ -204,7 +207,7 @@ static std::vector<char> exportToGlbBytes(
 
   // Export to the handle's path
   if (!exportToGlbFile(doc, handle.path(), merge_primitives, use_parallel,
-                       faceData, jsonCallback, binaryCallback)) {
+                       faceData, jsonCallback, binaryCallback, node_name_format)) {
     return {};
   }
 
@@ -226,7 +229,8 @@ std::vector<char> to_glb_bytes(const char *data, size_t data_len,
                                bool merge_primitives, bool use_parallel,
                                bool include_brep = false,
                                std::set<std::string> brep_types = {},
-                               bool include_materials = false) {
+                               bool include_materials = false,
+                               RWMesh_NameFormat node_name_format = RWMesh_NameFormat_InstanceOrProduct) {
 
   LoadResult loaded = loadBytes(data, data_len, file_type, tol_linear, tol_angle,
                                 tol_relative, use_parallel);
@@ -367,8 +371,8 @@ std::vector<char> to_glb_bytes(const char *data, size_t data_len,
   }
 
   std::vector<char> glbData =
-      exportToGlbBytes(loaded.doc, merge_primitives, use_parallel, faceDataPtr,
-                       jsonCallback, binaryCallback);
+      exportToGlbBytes(loaded.doc, merge_primitives, use_parallel, 
+                       faceDataPtr, jsonCallback, binaryCallback, node_name_format);
   closeDocument(loaded.doc);
 
   if (glbData.empty()) {
@@ -393,7 +397,7 @@ static int to_glb(const char *input_path, const char *output_path, FileType file
                   double tol_linear, double tol_angle,
                   bool tol_relative, bool merge_primitives, bool use_parallel,
                   bool include_brep = false, std::set<std::string> brep_types = {},
-                  bool include_materials = false) {
+                  bool include_materials = false, RWMesh_NameFormat node_name_format = RWMesh_NameFormat_InstanceOrProduct) {
 
   // Read input file
   std::ifstream inFile(input_path, std::ios::binary | std::ios::ate);
@@ -418,7 +422,7 @@ static int to_glb(const char *input_path, const char *output_path, FileType file
       to_glb_bytes(inputData.data(), inputData.size(), file_type, tol_linear,
                    tol_angle, tol_relative,
                    merge_primitives, use_parallel, include_brep, brep_types,
-                   include_materials);
+                   include_materials, node_name_format);
 
   if (glbData.empty()) {
     return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,12 +24,20 @@ NB_MODULE(_core, m) {
       .value("IGES", FileType::IGES)
       .export_values();
 
+  nb::enum_<RWMesh_NameFormat>(m, "NodeNameFormat")
+      .value("PRODUCT", RWMesh_NameFormat_Product)
+      .value("INSTANCE", RWMesh_NameFormat_Instance)
+      .value("INSTANCE_OR_PRODUCT", RWMesh_NameFormat_InstanceOrProduct)
+      .value("PRODUCT_OR_INSTANCE", RWMesh_NameFormat_ProductOrInstance)
+      .value("PRODUCT_AND_INSTANCE", RWMesh_NameFormat_ProductAndInstance)
+      .export_values();
+
   m.def(
       "to_glb_bytes",
       [](nb::bytes data, FileType file_type, double tol_linear,
          double tol_angle, bool tol_relative, bool merge_primitives,
          bool use_parallel, bool include_brep, std::set<std::string> brep_types,
-         bool include_materials) -> nb::bytes {
+         bool include_materials, RWMesh_NameFormat node_name_format) -> nb::bytes {
         // Force merge_primitives when BREP/materials requested (metadata requires merged faces)
         if ((include_brep || include_materials) && !merge_primitives) {
           std::cerr << "Warning: include_brep/include_materials require merge_primitives=true, enabling automatically" << std::endl;
@@ -42,7 +50,7 @@ NB_MODULE(_core, m) {
         std::vector<char> result =
             to_glb_bytes(input_data, input_data_len, file_type, tol_linear, tol_angle,
                          tol_relative, merge_primitives, use_parallel,
-                         include_brep, brep_types, include_materials);
+                         include_brep, brep_types, include_materials, node_name_format);
         return nb::bytes(result.data(), result.size());
       },
       R"doc(
@@ -70,6 +78,9 @@ brep_types
   If non-empty, only include these primitive types in brep_faces.
 include_materials
   Include material data in GLB asset.extras.materials.
+node_name_format
+  Name format for GLB nodes and meshes; controls whether instance
+  names, product names, or both are used.
 
 Returns
 -------
@@ -82,7 +93,8 @@ bytes
       nb::arg("tol_relative") = false, nb::arg("merge_primitives") = true,
       nb::arg("use_parallel") = true, nb::arg("include_brep") = false,
       nb::arg("brep_types") = std::set<std::string>(),
-      nb::arg("include_materials") = false);
+      nb::arg("include_materials") = false,
+      nb::arg("node_name_format") = RWMesh_NameFormat::RWMesh_NameFormat_InstanceOrProduct);
 
   // Backward compatibility wrappers
   m.def(
@@ -90,7 +102,7 @@ bytes
       [](const std::string &input_path, const std::string &output_path, double tol_linear,
          double tol_angle, bool tol_relative, bool merge_primitives,
          bool use_parallel, bool include_brep, std::set<std::string> brep_types,
-         bool include_materials) -> int {
+         bool include_materials, RWMesh_NameFormat node_name_format) -> int {
         // Force merge_primitives when BREP/materials requested (metadata requires merged faces)
         if ((include_brep || include_materials) && !merge_primitives) {
           std::cerr << "Warning: include_brep/include_materials require merge_primitives=true, enabling automatically" << std::endl;
@@ -98,7 +110,7 @@ bytes
         }
         return to_glb(input_path.c_str(), output_path.c_str(), FileType::STEP, tol_linear,
                       tol_angle, tol_relative, merge_primitives, use_parallel,
-                      include_brep, brep_types, include_materials);
+                      include_brep, brep_types, include_materials, node_name_format);
       },
       R"doc(
 Convert a step file to a GLB file.
@@ -138,7 +150,8 @@ include_materials
       nb::arg("tol_relative") = false, nb::arg("merge_primitives") = true,
       nb::arg("use_parallel") = true, nb::arg("include_brep") = false,
       nb::arg("brep_types") = std::set<std::string>(),
-      nb::arg("include_materials") = false);
+      nb::arg("include_materials") = false,
+      nb::arg("node_name_format") = RWMesh_NameFormat::RWMesh_NameFormat_InstanceOrProduct);
 
   m.def("step_to_obj", &step_to_obj,
         R"doc(


### PR DESCRIPTION
`RWGltf_CafWriter` supports configurable node name formatting via `SetNodeNameFormat`, but this was previously not exposed or used directly so OCCT's internal default was used unconditionally.

OCCT defaults to `INSTANCE_OR_PRODUCT`, which prioritizes internal instance labels over user-defined product names (e.g. "Housing", "Base Plate"). This can result in unreadable node names in the exported GLB hierarchy.

This change threads `node_name_format` through `to_glb_bytes` and `step_to_glb`. It still defaults to `INSTANCE_OR_PRODUCT` to not break default expected behavior, but now callers can override this with any `RWMesh_NameFormat` value as needed. Switching this to `PRODUCT_OR_INSTANCE` instead preserves the human readable names but falls back to the internal naming if needed.

Built a wheel and tested locally, `=== 33 passed in 5.94s ====`